### PR TITLE
Silent Audio Fallback for Twilio

### DIFF
--- a/src/sts/index.ts
+++ b/src/sts/index.ts
@@ -6,7 +6,10 @@ import { PhonicSTSWebSocket } from "./websocket";
 export class SpeechToSpeech {
   constructor(private readonly phonic: Phonic) {}
 
-  websocket(config: PhonicSTSConfig): PhonicSTSWebSocket {
+  websocket(
+    config: PhonicSTSConfig,
+    enableSilentAudioFallback = false,
+  ): PhonicSTSWebSocket {
     const wsBaseUrl = this.phonic.baseUrl.replace(/^http/, "ws");
     const queryString = new URLSearchParams({
       ...(this.phonic.__downstreamWebSocketUrl !== null && {
@@ -18,6 +21,12 @@ export class SpeechToSpeech {
       headers: this.phonic.headers,
     });
 
-    return new PhonicSTSWebSocket(ws, config);
+    const phonicSTSWebSocket = new PhonicSTSWebSocket(ws, config);
+
+    if (enableSilentAudioFallback) {
+      phonicSTSWebSocket.enableSilentAudioFallback(config.input_format);
+    }
+
+    return phonicSTSWebSocket;
   }
 }

--- a/src/sts/index.ts
+++ b/src/sts/index.ts
@@ -10,9 +10,7 @@ type PhonicSTSWebSocketOptions = {
 export class SpeechToSpeech {
   constructor(private readonly phonic: Phonic) {}
 
-  websocket(
-    config: PhonicSTSWebSocketOptions,
-  ): PhonicSTSWebSocket {
+  websocket(config: PhonicSTSWebSocketOptions): PhonicSTSWebSocket {
     const wsBaseUrl = this.phonic.baseUrl.replace(/^http/, "ws");
     const queryString = new URLSearchParams({
       ...(this.phonic.__downstreamWebSocketUrl !== null && {

--- a/src/sts/index.ts
+++ b/src/sts/index.ts
@@ -3,12 +3,15 @@ import type { Phonic } from "../phonic";
 import type { PhonicSTSConfig } from "./types";
 import { PhonicSTSWebSocket } from "./websocket";
 
+type PhonicSTSWebSocketOptions = {
+  enableSilentAudioFallback?: boolean;
+} & PhonicSTSConfig;
+
 export class SpeechToSpeech {
   constructor(private readonly phonic: Phonic) {}
 
   websocket(
-    config: PhonicSTSConfig,
-    enableSilentAudioFallback = false,
+    config: PhonicSTSWebSocketOptions,
   ): PhonicSTSWebSocket {
     const wsBaseUrl = this.phonic.baseUrl.replace(/^http/, "ws");
     const queryString = new URLSearchParams({
@@ -23,7 +26,7 @@ export class SpeechToSpeech {
 
     const phonicSTSWebSocket = new PhonicSTSWebSocket(ws, config);
 
-    if (enableSilentAudioFallback) {
+    if (config.enableSilentAudioFallback) {
       phonicSTSWebSocket.enableSilentAudioFallback(config.input_format);
     }
 

--- a/src/sts/utils.ts
+++ b/src/sts/utils.ts
@@ -1,0 +1,33 @@
+export const generateSilentAudio = (
+  input_format: "pcm_44100" | "mulaw_8000",
+  lengthMs: number,
+): string => {
+  const format = {
+    pcm_44100: {
+      sampleRate: 44100,
+      bytesPerSample: 2,
+      channels: 2,
+      silentValue: 0,
+    },
+    mulaw_8000: {
+      sampleRate: 8000,
+      bytesPerSample: 1,
+      channels: 1,
+      silentValue: 127, // 0x7F
+    },
+  };
+
+  const params = format[input_format];
+
+  const bytesPerMs =
+    (params.sampleRate * params.bytesPerSample * params.channels) / 1000;
+  const totalBytes = Math.ceil(bytesPerMs * lengthMs);
+
+  const buffer = new Uint8Array(totalBytes).fill(params.silentValue);
+
+  const binaryString = Array.from(buffer)
+    .map((byte) => String.fromCharCode(byte))
+    .join("");
+
+  return btoa(binaryString);
+};

--- a/src/sts/utils.ts
+++ b/src/sts/utils.ts
@@ -6,21 +6,18 @@ export const generateSilentAudio = (
     pcm_44100: {
       sampleRate: 44100,
       bytesPerSample: 2,
-      channels: 2,
       silentValue: 0,
     },
     mulaw_8000: {
       sampleRate: 8000,
       bytesPerSample: 1,
-      channels: 1,
       silentValue: 127, // 0x7F
     },
   };
 
   const params = format[input_format];
 
-  const bytesPerMs =
-    (params.sampleRate * params.bytesPerSample * params.channels) / 1000;
+  const bytesPerMs = (params.sampleRate * params.bytesPerSample) / 1000;
   const totalBytes = Math.ceil(bytesPerMs * lengthMs);
 
   const buffer = new Uint8Array(totalBytes).fill(params.silentValue);

--- a/src/sts/websocket.ts
+++ b/src/sts/websocket.ts
@@ -80,15 +80,15 @@ export class PhonicSTSWebSocket {
     input_format: "pcm_44100" | "mulaw_8000",
     intervalMs = 40,
   ) {
-    this.lastAudioSentTime = Date.now();
+    this.lastAudioSentTime = performance.now();
 
     if (this.silentAudioInterval) {
       clearInterval(this.silentAudioInterval);
     }
 
     this.silentAudioInterval = setInterval(() => {
-      const now = Date.now();
-      if (now - this.lastAudioSentTime >= intervalMs) {
+      const now = performance.now();
+      if (now - this.lastAudioSentTime >= intervalMs && this.isOpen) {
         const silentAudio = generateSilentAudio(input_format, intervalMs);
         this.audioChunk({ audio: silentAudio });
       }
@@ -114,6 +114,7 @@ export class PhonicSTSWebSocket {
     });
 
     if (this.isOpen) {
+      this.lastAudioSentTime = performance.now();
       this.ws.send(audiochunkMessage);
     } else {
       this.buffer.push(audiochunkMessage);


### PR DESCRIPTION
For some calls, Twilio does not send silent chunks, but a complete audio stream is required by Phonic. 

We can deal with that by adding to the Phonic Node Client and option that when turned on, sends silent audio chunks when there has not been audio for some time. 

This may not be the best place to deal with it, we can also deal with this in the client code, or in our server logic, but this is a very simple solution that works. 

40ms was selected as the default here because it is larger than the Twilio, Telnyx, and browser audio chunk sizes. 

Before:
<img width="1456" alt="image" src="https://github.com/user-attachments/assets/c37cd283-1f35-4403-b6f6-7cd1fd3be557" />

After:
<img width="1468" alt="image" src="https://github.com/user-attachments/assets/a2ac39cc-3b20-46c8-9156-a1ecfcef3e2d" />


