### PR TITLE
Update STS Websocket Messages

### DIFF
--- a/.changeset/late-shirts-beam.md
+++ b/.changeset/late-shirts-beam.md
@@ -1,0 +1,5 @@
+---
+"phonic": patch
+---
+
+Add new STS websocket messages to types and README.md

--- a/README.md
+++ b/README.md
@@ -423,6 +423,27 @@ phonicWebSocket.onError((event) => {
 
 ### Messages that Phonic sends back to you
 
+#### `conversation_created`
+
+```ts
+{
+  type: "conversation_created";
+  conversation_id: string;
+}
+```
+
+Sent when the conversation has been successfully created.
+
+#### `ready_to_start_conversation`
+
+```ts
+{
+  type: "ready_to_start_conversation";
+}
+```
+
+Sent when Phonic is ready to begin processing audio. You should start sending audio chunks after receiving this message.
+
 #### `input_text`
 
 ```ts
@@ -456,6 +477,26 @@ These are the assistant response audio chunks.
 
 Sent after the last "audio_chunk" is sent.
 
+#### `user_started_speaking`
+
+```ts
+{
+  type: "user_started_speaking";
+}
+```
+
+Sent when the user begins speaking.
+
+#### `user_finished_speaking`
+
+```ts
+{
+  type: "user_finished_speaking";
+}
+```
+
+Sent when the user stops speaking.
+
 #### `interrupted_response`
 
 ```ts
@@ -467,7 +508,17 @@ Sent after the last "audio_chunk" is sent.
 
 Sent when the user interrupts the assistant, after the user has finished speaking.
 
-### `assistant_ended_conversation`
+#### `assistant_chose_not_to_respond`
+
+```ts
+{
+  type: "assistant_chose_not_to_respond";
+}
+```
+
+Sent when the assistant decides not to respond to the user's input.
+
+#### `assistant_ended_conversation`
 
 ```ts
 {
@@ -476,6 +527,44 @@ Sent when the user interrupts the assistant, after the user has finished speakin
 ```
 
 Sent when the assistant decides to end the conversation.
+
+#### `tool_call`
+
+```ts
+{
+  type: "tool_call";
+  id: string;
+  tool: {
+    id: string;
+    name: string;
+  };
+  endpoint_url: string | null;
+  endpoint_timeout_ms: number | null;
+  endpoint_called_at: string | null;
+  request_body: object | null;
+  response_body: object | null;
+  response_status_code: number | null;
+  timed_out: boolean | null;
+  error_message: string | null;
+}
+```
+
+Sent when a tool is called during the conversation. Built-in tools will have null values for endpoint-related fields.
+
+#### `error`
+
+```ts
+{
+  type: "error";
+  error: {
+    message: string;
+    code?: string;
+  };
+  param_errors?: Record<string, string>;
+}
+```
+
+Sent when an error occurs during the conversation.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -548,8 +548,10 @@ Sent when the assistant decides to end the conversation.
   error_message: string | null;
 }
 ```
-
 Sent when a tool is called during the conversation. Built-in tools will have null values for endpoint-related fields.
+
+When a custom tool is called, the `request_body` field always includes a `call_info` field.
+If the conversation is not a phone call, `call_info` will be `null`. If it is a phone call, `call_info` will be an object with `from_phone_number` and `to_phone_number` fields, both formatted as E.164 phone numbers (e.g., "+1234567890").
 
 #### `error`
 

--- a/src/sts/types.ts
+++ b/src/sts/types.ts
@@ -38,6 +38,10 @@ export type PhonicSTSConfig =
 
 export type PhonicSTSWebSocketResponseMessage =
   | {
+      type: "conversation_created";
+      conversation_id: string;
+    }
+  | {
       type: "ready_to_start_conversation";
     }
   | {
@@ -50,15 +54,47 @@ export type PhonicSTSWebSocketResponseMessage =
       audio: string;
     }
   | {
+      type: "audio_finished";
+    }
+  | {
       type: "is_user_speaking";
       isUserSpeaking: boolean;
+    }
+  | {
+      type: "user_started_speaking";
+    }
+  | {
+      type: "user_finished_speaking";
     }
   | {
       type: "interrupted_response";
       interruptedResponse: string;
     }
   | {
+      type: "assistant_chose_not_to_respond";
+    }
+  | {
       type: "assistant_ended_conversation";
+    }
+  | {
+      type: "dtmf";
+      digits: string;
+    }
+  | {
+      type: "tool_call";
+      id: string;
+      tool: {
+        id: string;
+        name: string;
+      };
+      endpoint_url: string | null;
+      endpoint_timeout_ms: number | null;
+      endpoint_called_at: string | null;
+      request_body: object | null;
+      response_body: object | null;
+      response_status_code: number | null;
+      timed_out: boolean | null;
+      error_message: string | null;
     }
   | {
       type: "error";


### PR DESCRIPTION
Adds the following messages, which were missing but currently supported.

conversation_created - Sent when the conversation has been successfully created (includes conversation_id)
ready_to_start_conversation - Sent when Phonic is ready to begin processing audio
user_started_speaking - Event sent when the user begins speaking
user_finished_speaking - Event sent when the user stops speaking
assistant_chose_not_to_respond - Sent when the assistant decides not to respond to user input
tool_call - Comprehensive information about tool calls during the conversation
error - Error messages with optional parameter errors

Does not add legacy messages:
"dtmf" and "is_user_speaking"