### PR TITLE
Change UpdateToolParams to allow for null types when switching Tool Type

### DIFF
--- a/.changeset/lazy-actors-talk.md
+++ b/.changeset/lazy-actors-talk.md
@@ -1,0 +1,5 @@
+---
+"phonic": patch
+---
+
+Allow for null types for parameters in UpdateToolParams that should be set to null when switching between custom_websocket and custom_webhook tools

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -94,11 +94,11 @@ export type UpdateToolParams = {
   description?: string;
   type?: "custom_webhook" | "custom_websocket";
   executionMode?: ExecutionMode;
-  endpointMethod?: "POST";
-  endpointUrl?: string;
-  endpointHeaders?: Record<string, string>;
-  endpointTimeoutMs?: number;
-  toolCallOutputTimeoutMs?: number;
+  endpointMethod?: "POST" | null;
+  endpointUrl?: string | null;
+  endpointHeaders?: Record<string, string> | null;
+  endpointTimeoutMs?: number | null;
+  toolCallOutputTimeoutMs?: number | null;
   parameters?: ToolParameters;
 };
 


### PR DESCRIPTION
When switching a tool between `custom_websocket` and `custom_webhook` types,  we need to set certain parameters explicitly to null, as they are specific to either Websocket or Webhook tools. 

When updating a Websocket Tool to Webhook:
`tool_call_output_timeout_ms` must be set to `null`

When updating from a Webhook to a Websocket tool:
`endpoint_method`, `endpoint_url`, `endpoint_headers`, and `endpoint_timeout_ms` must be set to `null`

When make change `UpdateToolParams` to allow for this behavior in the SDK. 