### PR TITLE
Add audio speed to Agents and STS

### DIFF
--- a/.changeset/famous-mugs-count.md
+++ b/.changeset/famous-mugs-count.md
@@ -1,0 +1,5 @@
+---
+"phonic": patch
+---
+
+Add audio_speed to agents and STS config

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ const result = await phonic.agents.create({
   timezone: "Australia/Melbourne", // Defaults to "America/Los_Angeles"
   audioFormat: "mulaw_8000", // Defaults to "pcm_44100". Must be "mulaw_8000" when `phoneNumber` is "assign-automatically"
   voiceId: "sarah", // Defaults to "grant"
+  audioSpeed: 1.1, // Defaults to 1.0. Must be between 0.5 and 1.5, multiple of 0.1
   welcomeMessage: "Hello, how can I help you?", // Defaults to ""
   systemPrompt: "You are an expert in {{subject}}. Be kind to {{user_name}}.", // Defaults to "Respond in 1-2 sentences."
   templateVariables: {
@@ -117,6 +118,7 @@ const result = await phonic.agents.update("chris", {
   timezone: "Australia/Melbourne",
   voiceId: "sarah",
   audioFormat: "mulaw_8000", // Must be "mulaw_8000" when `phoneNumber` is "assign-automatically"
+  audioSpeed: 1.1, // Must be between 0.5 and 1.5, multiple of 0.1
   welcomeMessage: "Hello, how can I help you?",
   systemPrompt: "You are an expert in {{subject}}. Be kind to {{user_name}}.",
   templateVariables: {
@@ -154,6 +156,7 @@ const result = await phonic.agents.upsert({
   timezone: "Australia/Melbourne",
   voiceId: "sarah",
   audioFormat: "mulaw_8000", // Must be "mulaw_8000" when `phoneNumber` is "assign-automatically"
+  audioSpeed: 1.1, // Defaults to 1.0. Must be between 0.5 and 1.5, multiple of 0.1
   welcomeMessage: "Hello, how can I help you?",
   systemPrompt: "You are an expert in {{subject}}. Be kind to {{user_name}}.",
   templateVariables: {

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -101,6 +101,7 @@ export class Agents {
           params.phoneNumber === "assign-automatically"
             ? "mulaw_8000"
             : params.audioFormat,
+        audio_speed: params.audioSpeed,
         voice_id: params.voiceId,
         welcome_message: params.welcomeMessage,
         system_prompt: params.systemPrompt,
@@ -136,6 +137,7 @@ export class Agents {
             ? "mulaw_8000"
             : params.audioFormat,
         voice_id: params.voiceId,
+        audio_speed: params.audioSpeed,
         welcome_message: params.welcomeMessage,
         system_prompt: params.systemPrompt,
         template_variables: this.getTemplateVariablesForBody(
@@ -171,6 +173,7 @@ export class Agents {
         voice_id: params.voiceId,
         welcome_message: params.welcomeMessage,
         system_prompt: params.systemPrompt,
+        audio_speed: params.audioSpeed,
         template_variables: this.getTemplateVariablesForBody(
           params.templateVariables,
         ),

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -46,6 +46,7 @@ interface AgentOptionalParams {
   project?: string;
   timezone?: string;
   voiceId?: string;
+  audioSpeed?: number;
   welcomeMessage?: string;
   systemPrompt?: string;
   templateVariables?: Record<string, { defaultValue: string | null }>;

--- a/src/sts/types.ts
+++ b/src/sts/types.ts
@@ -11,6 +11,7 @@ interface PhonicSTSConfigBase {
   input_format: "pcm_44100" | "mulaw_8000";
   output_format?: "pcm_44100" | "mulaw_8000";
   voice_id?: string;
+  audio_speed?: number; // API default: 1.0 // Must be between 0.5 and 1.5, multiple of 0.1
   welcome_message?: string;
   system_prompt?: string;
   template_variables?: Record<string, string>;


### PR DESCRIPTION
- Adds `audio_speed` param to Agents and STS

Tested with Phonic Conversation Demo and tested CRUD-ing seperately