### PR TITLE
Add fields to PhonicConfigurationEndpointResponsePayload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "phonic",
-    "version": "0.32.00",
+    "version": "0.32.0",
     "private": false,
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "phonic",
-    "version": "0.31.17",
+    "version": "0.32.00",
     "private": false,
     "repository": {
         "type": "git",

--- a/src/api/types/overrides.ts
+++ b/src/api/types/overrides.ts
@@ -1,3 +1,4 @@
+import type { Phonic } from "../..";
 import type { Conversation } from "./Conversation";
 
 type PhonicTool = "keypad_input" | "natural_conversation_ending" | (string & {});
@@ -26,6 +27,8 @@ export type PhonicConfigurationEndpointResponsePayload = {
     template_variables?: Record<string, string>;
     tools?: Array<PhonicTool>;
     boosted_keywords?: string[];
+    default_language?: Phonic.LanguageCode;
+    additional_languages?: Phonic.LanguageCode[];
     metadata?: unknown;
 };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Optional TypeScript fields and a semver bump only; no runtime or auth logic changes.
> 
> **Overview**
> Extends **`PhonicConfigurationEndpointResponsePayload`** with optional **`default_language`** and **`additional_languages`** (`Phonic.LanguageCode`), so callers handling the configuration endpoint can type language overrides returned at conversation start—aligned with agent create/update types.
> 
> Bumps the package from **0.31.17** to **0.32.0** (minor release for the type change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a74410285411a6cb6b0bbf37898c35156a8d2a1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API configuration endpoint now exposes language preferences: a default language and a list of additional languages to improve localized content delivery.

* **Chores**
  * Package version bumped to 0.32.0 to deploy the new language preference support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->