### PR TITLE
1.3 Phonic Node publish action

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -10,3 +10,4 @@ src/api/resources/conversations/client/Client.ts
 .fern/replay.lock
 .fern/replay.yml
 .gitattributes
+.github/workflows/publish.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          # We never push from this job, so don't leave the token in git config.
+          persist-credentials: false
 
       - name: Set up node
         uses: actions/setup-node@v6
@@ -34,12 +37,15 @@ jobs:
         run: echo "version=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
 
       # Don't fail on unrelated merges to main — only publish a version that isn't live yet.
+      # Version is passed via env (not inlined with ${{ }}) to avoid shell injection.
       - name: Check if already published
         id: check
+        env:
+          VERSION: ${{ steps.v.outputs.version }}
         run: |
-          if npm view "phonic@${{ steps.v.outputs.version }}" version >/dev/null 2>&1; then
+          if npm view "phonic@${VERSION}" version >/dev/null 2>&1; then
             echo "publish=false" >> "$GITHUB_OUTPUT"
-            echo "phonic@${{ steps.v.outputs.version }} already on npm — skipping."
+            echo "phonic@${VERSION} already on npm — skipping."
           else
             echo "publish=true" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,59 @@
+name: Publish to npm
+
+# Publishes the package to npm when a PR is merged into main (i.e. when the SDK PR that
+# fern-config opened gets reviewed and merged). The version is whatever is in package.json,
+# which fern-config bakes in when it opens the PR.
+#
+# Kept in .fernignore so Fern's regeneration doesn't remove it.
+#
+# Requires repo secret: NPM_TOKEN
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: publish-npm
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Set up node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Read package version
+        id: v
+        run: echo "version=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
+
+      # Don't fail on unrelated merges to main — only publish a version that isn't live yet.
+      - name: Check if already published
+        id: check
+        run: |
+          if npm view "phonic@${{ steps.v.outputs.version }}" version >/dev/null 2>&1; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "phonic@${{ steps.v.outputs.version }} already on npm — skipping."
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dependencies
+        if: steps.check.outputs.publish == 'true'
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        if: steps.check.outputs.publish == 'true'
+        run: yarn build
+
+      - name: Publish
+        if: steps.check.outputs.publish == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces automated public npm releases tied to merges to `main`; mis-versioned or duplicate publishes are mostly mitigated by the npm version check, but credential handling and release timing still warrant review.
> 
> **Overview**
> Adds **automated npm publishing** for the `phonic` package when `main` is updated, and protects the workflow from Fern SDK regeneration by listing `.github/workflows/publish.yml` in `.fernignore`.
> 
> The new **Publish to npm** workflow reads `package.json` version, **skips** install/build/publish if that version is already on npm (so routine merges to `main` don’t fail), otherwise runs `yarn install --frozen-lockfile`, `yarn build`, and `npm publish --access public` using `NPM_TOKEN`. It uses a `publish-npm` concurrency group and passes the version via env in the duplicate check to reduce shell-injection risk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10e6d492f26191de883b28c7f40fd8c1c4c7ed98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Set up automated npm package publishing workflow to publish on main when a new package version is detected, preventing duplicate publications.
  * Updated repository ignore configuration to exclude the publishing workflow file from other processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->