### PR TITLE
Fix npm publish: use OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,8 @@ name: Publish to npm
 #
 # Kept in .fernignore so Fern's regeneration doesn't remove it.
 #
-# Requires repo secret: NPM_TOKEN
+# Authenticates via npm OIDC trusted publishing (configured on the npm package),
+# so no NPM_TOKEN secret is needed. Requires `id-token: write` and npm >= 11.5.1.
 
 on:
   push:
@@ -19,6 +20,9 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -31,6 +35,10 @@ jobs:
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
+
+      # OIDC trusted publishing requires npm >= 11.5.1; node 20 ships npm 10.
+      - name: Upgrade npm
+        run: npm install -g npm@latest
 
       - name: Read package version
         id: v
@@ -60,6 +68,4 @@ jobs:
 
       - name: Publish
         if: steps.check.outputs.publish == 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,9 +5,7 @@ name: Publish to npm
 # which fern-config bakes in when it opens the PR.
 #
 # Kept in .fernignore so Fern's regeneration doesn't remove it.
-#
-# Authenticates via npm OIDC trusted publishing (configured on the npm package),
-# so no NPM_TOKEN secret is needed. Requires `id-token: write` and npm >= 11.5.1.
+# Authenticates via npm OIDC trusted publishing, so no NPM_TOKEN is needed.
 
 on:
   push:


### PR DESCRIPTION
## Summary
- The `Publish to npm` workflow (run `SDK regeneration (#195)`) failed with `npm error 404 Not Found - PUT https://registry.npmjs.org/phonic` while publishing `phonic@0.32.3`. The build and `npm pack` succeeded — only the upload failed.
- That 404-on-PUT is npm's way of reporting an **unauthorized** publish. The package now has an **OIDC trusted publisher** configured on npm, but the workflow still authenticated with a classic `NPM_TOKEN`, so the publish was rejected.
- This switches the job to OIDC trusted publishing to match the npm config.

## Changes
- Add `permissions: id-token: write` (+ `contents: read`) to the publish job.
- Upgrade npm to `>= 11.5.1` before publishing (node 20 ships npm 10, which has no OIDC support).
- Drop the `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env — OIDC handles auth and adds provenance.

## Effect
Once merged to `main`, the push trigger runs the publish job again; since `0.32.3` isn't on npm yet, it will publish via OIDC.

## Test plan
- [ ] Merge to `main` and confirm the `Publish to npm` run succeeds and `phonic@0.32.3` appears on npm.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved npm publish workflow security by switching to OIDC-based authentication and removing token-based credentials from CI.
  * Updated publishing tooling to meet current npm/Node requirements for reliable releases.
  * Preserved existing gating so releases are still published only when a new package version is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->