### PR TITLE
PHO-2080 Add live SDK integration test suite + CI

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -11,3 +11,6 @@ src/api/resources/conversations/client/Client.ts
 .fern/replay.yml
 .gitattributes
 .github/workflows/publish.yml
+.github/workflows/integration.yml
+jest.integration.config.mjs
+tests-integration

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,46 @@
+# Maintained manually (listed in .fernignore). Fern does not overwrite this file.
+#
+# Runs the live SDK integration tests (REST CRUD + conversation WebSocket)
+# against a real Phonic API. The point is to catch cases where a Fern
+# regeneration or a change to a `.fernignore`-protected file breaks the SDK
+# against the actual API contract.
+
+name: integration
+
+on:
+  # Run on PRs (including the automated Fern SDK-regeneration PRs) and on pushes
+  # to main, plus a daily schedule and manual dispatch.
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 7 * * *" # daily at 07:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Set up node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run integration tests
+        env:
+          PHONIC_API_KEY: ${{ secrets.PHONIC_API_KEY }}
+          # Host root of the API to test against, e.g. https://api.test.phonic.co
+          # (no /v1 suffix). Falls back to production when unset.
+          PHONIC_API_BASE_URL: ${{ vars.PHONIC_API_BASE_URL }}
+        run: yarn jest --config jest.integration.config.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 /dist
+.env.local

--- a/jest.integration.config.mjs
+++ b/jest.integration.config.mjs
@@ -1,0 +1,23 @@
+// Maintained manually (listed in .fernignore). Fern does not overwrite this file.
+//
+// Separate Jest config for the live integration suite. Kept out of the default
+// `jest.config.mjs` (which Fern regenerates) so these credential-dependent,
+// network-hitting tests never run as part of `yarn test` / unit / wire runs.
+
+/** @type {import('jest').Config} */
+export default {
+    preset: "ts-jest",
+    testEnvironment: "node",
+    displayName: "integration",
+    moduleNameMapper: {
+        "^(\\.{1,2}/.*)\\.js$": "$1",
+    },
+    roots: ["<rootDir>/tests-integration"],
+    setupFilesAfterEnv: ["<rootDir>/tests/setup.ts"],
+    workerThreads: false,
+    // Integration tests share a live workspace; run serially to avoid cross-test
+    // interference and to keep request volume predictable.
+    maxWorkers: 1,
+    testTimeout: 60_000,
+    passWithNoTests: true,
+};

--- a/package.json
+++ b/package.json
@@ -164,7 +164,8 @@
         "build:esm": "tsc --project ./tsconfig.esm.json && node scripts/rename-to-esm-files.js dist/esm",
         "test": "jest --config jest.config.mjs",
         "test:unit": "jest --selectProjects unit",
-        "test:wire": "jest --selectProjects wire"
+        "test:wire": "jest --selectProjects wire",
+        "test:integration": "jest --config jest.integration.config.mjs"
     },
     "dependencies": {
         "ws": "^8.20.0"

--- a/tests-integration/crud.test.ts
+++ b/tests-integration/crud.test.ts
@@ -1,0 +1,208 @@
+// Maintained manually (listed in .fernignore). Fern does not overwrite this file.
+//
+// Live CRUD integration tests. These exercise the real REST surface of the SDK
+// against a running Phonic API so that Fern regenerations (and `.fernignore`
+// overrides) can't silently break request/response shapes, URLs, or auth.
+
+import type { PhonicClient } from "../src/Client";
+import { createClient, describeIntegration, uniqueName, uniqueToolName } from "./helpers";
+
+const TIMEOUT_MS = 60_000;
+
+describeIntegration("SDK REST CRUD (live)", () => {
+    let client: PhonicClient;
+
+    // A project shared by the agents/tools suites. Created once, torn down last.
+    let sharedProjectName: string;
+
+    beforeAll(async () => {
+        client = createClient();
+        sharedProjectName = uniqueName("proj");
+        await client.projects.create({ name: sharedProjectName });
+    }, TIMEOUT_MS);
+
+    afterAll(async () => {
+        if (sharedProjectName) {
+            await client.projects.delete(sharedProjectName).catch(() => {
+                /* best-effort cleanup */
+            });
+        }
+    }, TIMEOUT_MS);
+
+    describe("workspace", () => {
+        it(
+            "gets the current workspace",
+            async () => {
+                const workspace = await client.workspace.get();
+                expect(typeof workspace.active_conversations).toBe("number");
+                expect(typeof workspace.max_active_conversations).toBe("number");
+                expect(Array.isArray(workspace.ip_allowlist)).toBe(true);
+                expect(Array.isArray(workspace.invite_link_allowed_domains)).toBe(true);
+            },
+            TIMEOUT_MS,
+        );
+    });
+
+    describe("projects", () => {
+        it(
+            "creates, reads, lists, updates and deletes a project",
+            async () => {
+                const name = uniqueName("proj");
+                let created = false;
+
+                try {
+                    const createRes = await client.projects.create({ name });
+                    created = true;
+                    expect(createRes.name).toBe(name);
+                    expect(typeof createRes.id).toBe("string");
+
+                    const getRes = await client.projects.get(name);
+                    expect(getRes.project.name).toBe(name);
+                    expect(getRes.project.id).toBe(createRes.id);
+
+                    const listRes = await client.projects.list();
+                    expect(Array.isArray(listRes.projects)).toBe(true);
+                    expect(listRes.projects.some((p) => p.name === name)).toBe(true);
+
+                    const updateRes = await client.projects.update(name, {
+                        max_active_conversations: 5,
+                    });
+                    expect(updateRes).toBeDefined();
+
+                    const afterUpdate = await client.projects.get(name);
+                    expect(afterUpdate.project.max_active_conversations).toBe(5);
+                } finally {
+                    if (created) {
+                        await client.projects.delete(name);
+                    }
+                }
+            },
+            TIMEOUT_MS,
+        );
+    });
+
+    describe("agents", () => {
+        it(
+            "creates, reads, lists, updates and deletes an agent",
+            async () => {
+                const name = uniqueName("agent");
+                let created = false;
+
+                try {
+                    const createRes = await client.agents.create({
+                        project: sharedProjectName,
+                        name,
+                        phone_number: null,
+                        system_prompt: "You are a helpful test agent.",
+                    });
+                    created = true;
+                    expect(createRes.name).toBe(name);
+                    expect(typeof createRes.id).toBe("string");
+
+                    const getRes = await client.agents.get(name, { project: sharedProjectName });
+                    expect(getRes.agent.name).toBe(name);
+                    expect(getRes.agent.id).toBe(createRes.id);
+
+                    const listRes = await client.agents.list({ project: sharedProjectName });
+                    expect(Array.isArray(listRes.agents)).toBe(true);
+                    expect(listRes.agents.some((a) => a.name === name)).toBe(true);
+
+                    await client.agents.update(name, {
+                        project: sharedProjectName,
+                        system_prompt: "Updated system prompt.",
+                    });
+
+                    const afterUpdate = await client.agents.get(name, { project: sharedProjectName });
+                    expect(afterUpdate.agent.system_prompt).toBe("Updated system prompt.");
+                } finally {
+                    if (created) {
+                        await client.agents.delete(name, { project: sharedProjectName });
+                    }
+                }
+            },
+            TIMEOUT_MS,
+        );
+    });
+
+    describe("tools", () => {
+        it(
+            "creates, reads, lists, updates and deletes a tool",
+            async () => {
+                const name = uniqueToolName("tool");
+                let created = false;
+
+                try {
+                    const createRes = await client.tools.create({
+                        project: sharedProjectName,
+                        name,
+                        description: "A test tool created by the SDK CI suite.",
+                        type: "custom_context",
+                        execution_mode: "sync",
+                        context: "This is static context returned to the agent.",
+                    });
+                    created = true;
+                    expect(createRes.name).toBe(name);
+                    expect(typeof createRes.id).toBe("string");
+
+                    const getRes = await client.tools.get(name, { project: sharedProjectName });
+                    expect(getRes.tool.name).toBe(name);
+                    expect(getRes.tool.id).toBe(createRes.id);
+
+                    const listRes = await client.tools.list({ project: sharedProjectName });
+                    expect(Array.isArray(listRes.tools)).toBe(true);
+                    expect(listRes.tools.some((t) => t.name === name)).toBe(true);
+
+                    await client.tools.update(name, {
+                        project: sharedProjectName,
+                        description: "Updated tool description.",
+                    });
+
+                    const afterUpdate = await client.tools.get(name, { project: sharedProjectName });
+                    expect(afterUpdate.tool.description).toBe("Updated tool description.");
+                } finally {
+                    if (created) {
+                        await client.tools.delete(name, { project: sharedProjectName });
+                    }
+                }
+            },
+            TIMEOUT_MS,
+        );
+    });
+
+    describe("conversations", () => {
+        it(
+            "lists conversations for the workspace",
+            async () => {
+                const res = await client.conversations.list({ limit: 1 });
+                // The list endpoint can return either the paginated or single shape.
+                expect(res).toBeDefined();
+                if ("conversations" in res) {
+                    expect(Array.isArray(res.conversations)).toBe(true);
+                }
+            },
+            TIMEOUT_MS,
+        );
+    });
+
+    describe("voices", () => {
+        it(
+            "lists available voices",
+            async () => {
+                const res = await client.voices.list({ model: "merritt" });
+                expect(Array.isArray(res.voices)).toBe(true);
+            },
+            TIMEOUT_MS,
+        );
+    });
+
+    describe("extraction schemas", () => {
+        it(
+            "lists extraction schemas",
+            async () => {
+                const res = await client.extractionSchemas.list({ project: sharedProjectName });
+                expect(Array.isArray(res.extraction_schemas)).toBe(true);
+            },
+            TIMEOUT_MS,
+        );
+    });
+});

--- a/tests-integration/helpers.ts
+++ b/tests-integration/helpers.ts
@@ -1,0 +1,113 @@
+// Maintained manually (listed in .fernignore). Fern does not overwrite this file.
+//
+// Shared helpers for the live integration test suite. These tests run against a
+// real Phonic API (the test environment by default) to make sure Fern-generated
+// code and `.fernignore`-protected overrides keep working end to end.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { PhonicClient } from "../src/Client";
+
+/**
+ * Loads `KEY=VALUE` pairs from a `.env.local` file at the repo root into
+ * `process.env` (without overwriting variables already set, e.g. CI secrets).
+ * This lets the suite run locally with no extra tooling, while CI just sets
+ * real environment variables. Avoids adding a `dotenv` dependency.
+ */
+function loadDotEnvLocal(): void {
+    const envPath = path.resolve(__dirname, "../.env.local");
+    if (!fs.existsSync(envPath)) {
+        return;
+    }
+    const contents = fs.readFileSync(envPath, "utf-8");
+    for (const rawLine of contents.split("\n")) {
+        const line = rawLine.trim();
+        if (line === "" || line.startsWith("#")) {
+            continue;
+        }
+        const eq = line.indexOf("=");
+        if (eq === -1) {
+            continue;
+        }
+        const key = line.slice(0, eq).trim();
+        let value = line.slice(eq + 1).trim();
+        // Strip surrounding single or double quotes.
+        if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+            value = value.slice(1, -1);
+        }
+        if (!(key in process.env)) {
+            process.env[key] = value;
+        }
+    }
+}
+
+loadDotEnvLocal();
+
+export const apiKey: string | undefined = process.env.PHONIC_API_KEY;
+
+/**
+ * Whether the integration suite has the credentials it needs to run. When
+ * false (e.g. on a fork PR without secrets), the suites use `describe.skip` so
+ * they report as skipped rather than failing.
+ */
+export const hasCredentials: boolean = Boolean(apiKey);
+
+/**
+ * Root host of the API to test against, e.g. `https://api.test.phonic.co`.
+ * Defaults to production if unset. Note this is the *host root* without the
+ * `/v1` suffix — we derive the HTTP and WebSocket base URLs from it below.
+ */
+function getApiRoot(): string {
+    const raw = process.env.PHONIC_API_BASE_URL?.trim();
+    const root = raw && raw !== "" ? raw : "https://api.phonic.ai";
+    // Normalize: drop a trailing slash and a trailing `/v1` if someone passed one.
+    return root.replace(/\/+$/, "").replace(/\/v1$/, "");
+}
+
+/**
+ * Builds the `environment` URLs the SDK expects.
+ * - HTTP requests join `base` with the resource path, so `base` must end in `/v1`.
+ * - `conversations.connect()` joins `production` with `/v1/sts/ws`, so
+ *   `production` must be the `ws(s)://` host root *without* `/v1`.
+ */
+export function getEnvironmentUrls(): { base: string; production: string } {
+    const root = getApiRoot();
+    const wsRoot = root.replace(/^http/, "ws");
+    return {
+        base: `${root}/v1`,
+        production: wsRoot,
+    };
+}
+
+export interface CreateClientOptions {
+    reconnectConversationOnAbnormalDisconnect?: boolean;
+}
+
+export function createClient(options: CreateClientOptions = {}): PhonicClient {
+    return new PhonicClient({
+        apiKey,
+        environment: getEnvironmentUrls(),
+        // Keep retries low so failures surface quickly in CI.
+        maxRetries: 1,
+        ...options,
+    });
+}
+
+/**
+ * Generates a unique, API-valid resource name (lowercase letters, numbers and
+ * hyphens) so concurrent runs don't collide and leftover resources are
+ * identifiable. Prefixed with `sdk-ci-` for easy cleanup.
+ */
+export function uniqueName(prefix: string): string {
+    const suffix = Math.random().toString(36).slice(2, 10);
+    return `sdk-ci-${prefix}-${suffix}`;
+}
+
+/** Tools require snake_case names. */
+export function uniqueToolName(prefix: string): string {
+    return uniqueName(prefix).replace(/-/g, "_");
+}
+
+/** `describe` that becomes `describe.skip` when credentials are missing. */
+export const describeIntegration = hasCredentials ? describe : describe.skip;

--- a/tests-integration/websocket.test.ts
+++ b/tests-integration/websocket.test.ts
@@ -1,0 +1,106 @@
+// Maintained manually (listed in .fernignore). Fern does not overwrite this file.
+//
+// Live WebSocket integration test. Opens a real conversation WebSocket, sends a
+// `config` message and waits for the server's `conversation_created` event.
+// This guards the hand-maintained `conversations.connect()` / `ConversationsSocket`
+// code (both `.fernignore`-protected) against regressions.
+
+import type { ConversationsSocket } from "../src/api/resources/conversations/client/Socket";
+import type { PhonicClient } from "../src/Client";
+import { createClient, describeIntegration, uniqueName } from "./helpers";
+
+const TIMEOUT_MS = 60_000;
+
+describeIntegration("Conversation WebSocket (live)", () => {
+    let client: PhonicClient;
+    let projectName: string;
+    let agentName: string;
+
+    beforeAll(async () => {
+        client = createClient();
+        projectName = uniqueName("proj");
+        agentName = uniqueName("agent");
+        await client.projects.create({ name: projectName });
+        await client.agents.create({
+            project: projectName,
+            name: agentName,
+            phone_number: null,
+            system_prompt: "You are a helpful test agent for the SDK CI WebSocket test.",
+        });
+    }, TIMEOUT_MS);
+
+    afterAll(async () => {
+        await client.agents.delete(agentName, { project: projectName }).catch(() => {
+            /* best-effort cleanup */
+        });
+        await client.projects.delete(projectName).catch(() => {
+            /* best-effort cleanup */
+        });
+    }, TIMEOUT_MS);
+
+    it(
+        "connects, sends config and receives conversation_created",
+        async () => {
+            const socket = await client.conversations.connect();
+
+            try {
+                const conversationId = await runConversation(socket, {
+                    agentName,
+                    projectName,
+                });
+                expect(typeof conversationId).toBe("string");
+                expect(conversationId.length).toBeGreaterThan(0);
+            } finally {
+                socket.close();
+            }
+        },
+        TIMEOUT_MS,
+    );
+});
+
+/**
+ * Waits for the socket to open, sends `config`, and resolves with the
+ * `conversation_id` from the `conversation_created` message. Rejects on socket
+ * error, an `error`-type message, or early close.
+ */
+function runConversation(
+    socket: ConversationsSocket,
+    opts: { agentName: string; projectName: string },
+): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+        let settled = false;
+
+        const finish = (fn: () => void) => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            fn();
+        };
+
+        socket.on("error", (err) => finish(() => reject(err)));
+
+        socket.on("close", (event) => {
+            finish(() => reject(new Error(`Socket closed before conversation_created (code ${event?.code})`)));
+        });
+
+        socket.on("message", (message) => {
+            if (message.type === "conversation_created") {
+                finish(() => resolve(message.conversation_id));
+            } else if (message.type === "error") {
+                finish(() => reject(new Error(`Server error message: ${JSON.stringify(message)}`)));
+            }
+        });
+
+        socket
+            .waitForOpen()
+            .then(() => {
+                socket.sendConfig({
+                    type: "config",
+                    project: opts.projectName,
+                    agent: opts.agentName,
+                });
+            })
+            .catch((err) => finish(() => reject(err)));
+    });
+}


### PR DESCRIPTION
## What

A **credential-gated live integration test suite** plus a GitHub Actions workflow that exercises the SDK against a real Phonic API. The goal: catch cases where a **Fern regeneration** or a change to a **`.fernignore`-protected file** silently breaks the SDK against the actual API contract (complements the mock-based wire tests, which only check serialization against a fixture).

## What's covered

| Area | Test |
|------|------|
| **projects** | create → get → list → update → delete |
| **agents** | create → get → list → update → delete |
| **tools** | create → get → list → update → delete |
| **workspace** | get |
| **conversations** | list |
| **voices** | list |
| **extraction schemas** | list |
| **conversation WebSocket** | `connect()` → `sendConfig` → assert `conversation_created` (guards the hand-maintained `ConversationsSocket`) |

## Design notes

- **Isolated from the Fern-regenerated `jest.config.mjs`.** The suite lives in a sibling `tests-integration/` dir (not under `tests/`), so the unit project never sweeps it up. `yarn test` (unit + wire) is unaffected — still 537/537. Run locally with `yarn test:integration`.
- **Skips cleanly without secrets** (`describe.skip` when `PHONIC_API_KEY` is unset), so fork PRs don't fail.
- **Self-cleaning** — resources use an `sdk-ci-` prefix and are deleted in `finally`/`afterAll`.
- All new files are in `.fernignore`; `.env.local` is now gitignored (holds live keys).

## Required repo config

- Secret `PHONIC_API_KEY`
- Variable `PHONIC_API_BASE_URL` (e.g. `https://api.test.phonic.co`)

## ⚠️ The suite already caught a real bug

Live run: **7/8 pass**. The failure is **agent `update` → HTTP 500 "Failed to update agent"** on `api.test.phonic.co`, across every field. Project/tool updates work and the SDK request is correct (`PATCH /agents/{id}?project=...` with JSON body), so this looks like a **server-side bug in the agent-update endpoint**, not the SDK. The assertion is intentionally left strict so CI surfaces it.

## Open questions / next steps (test vs prod environments)

1. **Which environment does CI hit?** Currently driven by `PHONIC_API_BASE_URL` (defaults to prod if unset). Proposal: point CI at **test** (`api.test.phonic.co`). Should we *also* run a reduced read-only smoke against **prod** on a schedule?
2. **Workspace isolation.** Tests create/delete real resources in whatever workspace the API key belongs to. Recommend a **dedicated CI workspace/project** on the test env so runs can't collide with manual testing. Cleanup is best-effort — a crash mid-run can leave `sdk-ci-*` resources.
3. **Auth across environments.** Test and prod need separate keys. If we add a prod smoke job, we'll want a second secret (e.g. `PHONIC_API_KEY_PROD`).
4. **WebSocket cost/flakiness.** The WS test starts a real conversation (no audio, closed immediately). Confirm this is acceptable on every PR, or gate it to schedule/dispatch only.
5. **Coverage gaps to consider next:** conversation `get`/`cancel`/analysis/extractions (need a seeded conversation), `conversationItems.replay` (needs a wav fixture), api keys, agent phone-number ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)