### PR TITLE
Fix npm publishing on Node 26

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,10 +31,10 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 26
           registry-url: https://registry.npmjs.org
 
-      # OIDC trusted publishing requires npm >= 11.5.1; node 20 ships npm 10.
+      # OIDC trusted publishing requires npm >= 11.5.1.
       - name: Upgrade npm
         run: npm install -g npm@latest
 


### PR DESCRIPTION
## Summary
- run the npm publish workflow on Node 26 so `npm@latest` satisfies its engine requirements
- keep the npm upgrade required for OIDC trusted publishing
- allow the pending `phonic@0.32.9` package to publish when this PR merges

## Test plan
- [x] `git diff --check`
- [ ] Merge and verify the publish workflow releases `phonic@0.32.9`

Made with [Cursor](https://cursor.com)