### PR TITLE
Notify monophonic on release (sync-example-repos trigger)

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -1,0 +1,23 @@
+# Add as .github/workflows/release-dispatch.yml in BOTH
+# Phonic-Co/phonic-node and Phonic-Co/phonic-python.
+# Kept deliberately tiny: Fern manages these repos, so custom surface
+# should be minimal. Requires secret MONOPHONIC_DISPATCH_PAT
+# (fine-grained PAT, monophonic repo, contents:read + actions:write —
+# or classic repo scope).
+name: Notify monophonic on release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch sdk-release to monophonic
+        run: |
+          curl -sS -X POST \
+            -H "Authorization: Bearer ${{ secrets.MONOPHONIC_DISPATCH_PAT }}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/Phonic-Co/monophonic/dispatches \
+            -d '{"event_type": "sdk-release", "client_payload": {"version": "${{ github.event.release.tag_name }}", "repo": "${{ github.repository }}"}}'


### PR DESCRIPTION
Fires a `repository_dispatch` (type `sdk-release`) to Phonic-Co/monophonic on every published release, triggering the example-repos sync agent (see Phonic-Co/monophonic#769). Deliberately tiny since this repo is Fern-managed.

**Requires secret** `MONOPHONIC_DISPATCH_PAT` in this repo (fine-grained PAT scoped to monophonic, actions:write) before merging — without it the job fails silently on release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds CI-only outbound dispatch on release; no application or auth logic changes, though a missing or invalid PAT would break the notify step on each release.
> 
> **Overview**
> Adds **`.github/workflows/release-dispatch.yml`**, a minimal GitHub Actions workflow that runs when a **release is published** and POSTs a **`repository_dispatch`** to **`Phonic-Co/monophonic`** with event type **`sdk-release`**.
> 
> The payload includes the release **tag** and **source repo** so monophonic can run the example-repos sync agent. Auth uses the repo secret **`MONOPHONIC_DISPATCH_PAT`** (must be configured before merge or the dispatch step will fail on release).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8837bdcb093373cc1d00b1f5c21407872b96250. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->