### PR TITLE
Reconnect on 1012 / 1001-restarting, not just 1006 (PHO-2278)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "phonic",
-    "version": "0.32.9",
+    "version": "0.32.10",
     "private": false,
     "repository": {
         "type": "git",

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -52,8 +52,8 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
         {
             "X-Fern-Language": "JavaScript",
             "X-Fern-SDK-Name": "phonic",
-            "X-Fern-SDK-Version": "0.32.9",
-            "User-Agent": "phonic/0.32.9",
+            "X-Fern-SDK-Version": "0.32.10",
+            "User-Agent": "phonic/0.32.10",
             "X-Fern-Runtime": core.RUNTIME.type,
             "X-Fern-Runtime-Version": core.RUNTIME.version,
         },

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -19,8 +19,9 @@ import * as environments from "./environments.js";
 export declare namespace PhonicClient {
     export type Options = BaseClientOptions & {
         /**
-         * When `true`, conversation WebSockets automatically reconnect after an
-         * abnormal disconnect (WebSocket close code 1006) using `reconnect_conv_id`.
+         * When `true`, conversation WebSockets automatically reconnect and resume
+         * after a non-deliberate disconnect (WebSocket close codes 1006, 1012, or
+         * 1001/"restarting") using `reconnect_conv_id`.
          * Defaults to `false` until the behavior is broadly validated in production;
          * set to `true` to opt in early.
          */

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -19,9 +19,9 @@ import * as environments from "./environments.js";
 export declare namespace PhonicClient {
     export type Options = BaseClientOptions & {
         /**
-         * When `true`, conversation WebSockets automatically reconnect and resume
-         * after a non-deliberate disconnect (WebSocket close codes 1006, 1012, or
-         * 1001/"restarting") using `reconnect_conv_id`.
+         * **Experimental.** When `true`, conversation WebSockets automatically
+         * reconnect and resume after a non-deliberate disconnect (WebSocket close
+         * codes 1006, 1012, or 1001/"restarting") using `reconnect_conv_id`.
          * Defaults to `false` until the behavior is broadly validated in production;
          * set to `true` to opt in early.
          */

--- a/src/api/resources/conversations/client/Client.ts
+++ b/src/api/resources/conversations/client/Client.ts
@@ -14,9 +14,9 @@ import { ConversationsSocket } from "./Socket.js";
 export declare namespace ConversationsClient {
     export type Options = BaseClientOptions & {
         /**
-         * When `true`, `connect()` uses session-aware reconnection on abnormal
-         * disconnect (1006). Set via `PhonicClient` options as
-         * `reconnectConversationOnAbnormalDisconnect`.
+         * When `true`, `connect()` uses session-aware reconnection on a
+         * non-deliberate disconnect (close codes 1006, 1012, or 1001/"restarting").
+         * Set via `PhonicClient` options as `reconnectConversationOnAbnormalDisconnect`.
          */
         reconnectConversationOnAbnormalDisconnect?: boolean;
     };

--- a/src/api/resources/conversations/client/Client.ts
+++ b/src/api/resources/conversations/client/Client.ts
@@ -14,8 +14,8 @@ import { ConversationsSocket } from "./Socket.js";
 export declare namespace ConversationsClient {
     export type Options = BaseClientOptions & {
         /**
-         * When `true`, `connect()` uses session-aware reconnection on a
-         * non-deliberate disconnect (close codes 1006, 1012, or 1001/"restarting").
+         * **Experimental.** When `true`, `connect()` uses session-aware reconnection
+         * on a non-deliberate disconnect (close codes 1006, 1012, or 1001/"restarting").
          * Set via `PhonicClient` options as `reconnectConversationOnAbnormalDisconnect`.
          */
         reconnectConversationOnAbnormalDisconnect?: boolean;

--- a/src/custom/ReconnectableConversationsSocket.ts
+++ b/src/custom/ReconnectableConversationsSocket.ts
@@ -144,7 +144,7 @@ export class ReconnectableConversationsSocket {
     }
 
     /**
-     * Not supported — reconnection after 1006 is handled automatically.
+     * Not supported — reconnection after a dropped connection is handled automatically.
      * To start a new conversation, create a new socket via client.conversations.connect().
      */
     public connect(): never {

--- a/src/custom/ReconnectableConversationsSocket.ts
+++ b/src/custom/ReconnectableConversationsSocket.ts
@@ -10,14 +10,14 @@ const GOING_AWAY = 1001;
 /** Whether a close means the disconnect was NOT a deliberate end of the
  *  conversation, so the SDK should transparently reconnect and resume it:
  *   - 1006 abnormal closure (socket died with no close frame)
- *   - 1012 service restart — a Fly proxy redeploy closes the client with
- *     1012/"restarting"; the conversation is still alive server-side within
- *     the grace window
+ *   - 1012 service restart — an edge proxy/load-balancer restart closes the
+ *     client with 1012/"restarting"; the conversation is still alive
+ *     server-side within the grace window
  *   - 1001 "going away" ONLY when the reason is "restarting" — a proxy drain
  *     can surface to the client as 1001/"restarting" instead of 1012. A bare
  *     1001 (empty/other reason) is a deliberate close (the caller ended the
  *     conversation, tab closed/suspended) and must NOT reconnect.
- *  Mirrors phonic-api's isReconnectableClose. All other codes (1000, 4000,
+ *  Matches the server's reconnect policy. All other codes (1000, 4000,
  *  4800, ...) are intentional closes. */
 const isReconnectableClose = (code: number, reason: string): boolean =>
     code === ABNORMAL_CLOSURE || code === SERVICE_RESTART || (code === GOING_AWAY && reason === "restarting");

--- a/src/custom/ReconnectableConversationsSocket.ts
+++ b/src/custom/ReconnectableConversationsSocket.ts
@@ -3,20 +3,34 @@ import type * as Phonic from "../api/index.js";
 import { ConversationsSocket } from "../api/resources/conversations/client/Socket.js";
 import { fromJson } from "../core/json.js";
 
-/** 1006 is the only close code that indicates an unexpected disconnect
- *  worth reconnecting for. All other codes (1000, 4000, 4800, etc.)
- *  are intentional server-side closes. */
 const ABNORMAL_CLOSURE = 1006;
+const SERVICE_RESTART = 1012;
+const GOING_AWAY = 1001;
+
+/** Whether a close means the disconnect was NOT a deliberate end of the
+ *  conversation, so the SDK should transparently reconnect and resume it:
+ *   - 1006 abnormal closure (socket died with no close frame)
+ *   - 1012 service restart — a Fly proxy redeploy closes the client with
+ *     1012/"restarting"; the conversation is still alive server-side within
+ *     the grace window
+ *   - 1001 "going away" ONLY when the reason is "restarting" — a proxy drain
+ *     can surface to the client as 1001/"restarting" instead of 1012. A bare
+ *     1001 (empty/other reason) is a deliberate close (the caller ended the
+ *     conversation, tab closed/suspended) and must NOT reconnect.
+ *  Mirrors phonic-api's isReconnectableClose. All other codes (1000, 4000,
+ *  4800, ...) are intentional closes. */
+const isReconnectableClose = (code: number, reason: string): boolean =>
+    code === ABNORMAL_CLOSURE || code === SERVICE_RESTART || (code === GOING_AWAY && reason === "restarting");
 
 const BASE_RECONNECT_DELAY_MS = 500;
 const MAX_RECONNECT_DELAY_MS = 5000;
 /** Safety cap: stop retrying if the server is completely unreachable.
  *  In normal operation the server's terminal codes (4800/4801) stop
- *  retries much sooner (within the 10s grace period). */
+ *  retries much sooner (within the 30s grace period). */
 const MAX_RECONNECT_ATTEMPTS = 10;
 
 export interface ReconnectableConversationsSocketArgs {
-    /** Called on 1006 to create a new socket with reconnect_conv_id. May be async (e.g. fresh auth). */
+    /** Called on a reconnectable close to create a new socket with reconnect_conv_id. May be async (e.g. fresh auth). */
     createReconnectSocket: (conversationId: string) => core.ReconnectingWebSocket | Promise<core.ReconnectingWebSocket>;
     /** Initial socket for the first connection. */
     socket: core.ReconnectingWebSocket;
@@ -32,9 +46,10 @@ type EventHandlers = {
 };
 
 /**
- * Wraps ConversationsSocket with automatic reconnection on 1006.
+ * Wraps ConversationsSocket with automatic reconnection on a reconnectable
+ * close (1006, 1012, or 1001/"restarting" — see isReconnectableClose).
  *
- * On abnormal closure, creates a brand new ReconnectingWebSocket (via the
+ * On such a close, creates a brand new ReconnectingWebSocket (via the
  * createReconnectSocket factory) and wraps it in a fresh ConversationsSocket,
  * forwarding all events to user-registered handlers.
  *
@@ -135,7 +150,7 @@ export class ReconnectableConversationsSocket {
     public connect(): never {
         throw new Error(
             "connect() is not supported on ReconnectableConversationsSocket. "
-            + "Reconnection after 1006 is automatic. To start a new conversation, "
+            + "Reconnection after an abnormal close is automatic. To start a new conversation, "
             + "call client.conversations.connect() again."
         );
     }
@@ -216,7 +231,7 @@ export class ReconnectableConversationsSocket {
         } catch {
             this._pendingReplacement = false;
             // Connection failed — schedule another attempt.
-            // The server's grace period (10s) is the natural limit;
+            // The server's grace period (30s) is the natural limit;
             // once it expires, the next attempt will get 4800 and stop.
             this._scheduleReconnect();
         }
@@ -257,7 +272,7 @@ export class ReconnectableConversationsSocket {
                 return;
             }
 
-            if (event.code === ABNORMAL_CLOSURE && this._conversationId !== null) {
+            if (isReconnectableClose(event.code, event.reason) && this._conversationId !== null) {
                 // We have a conversation to resume — cancel RWS's built-in
                 // auto-reconnect and handle it ourselves with reconnect_conv_id.
                 // _handleClose calls _connect() before notifying listeners,
@@ -267,8 +282,8 @@ export class ReconnectableConversationsSocket {
                 rawSocket.close();
                 this._scheduleReconnect();
             }
-            // 1006 without conversationId: let RWS handle transport-level
-            // reconnect normally (starts a fresh conversation).
+            // Reconnectable close without conversationId: let RWS handle
+            // transport-level reconnect normally (starts a fresh conversation).
         };
 
         rawSocket.addEventListener("message", onMessage);

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const SDK_VERSION = "0.32.9";
+export const SDK_VERSION = "0.32.10";

--- a/tests/custom.test.ts
+++ b/tests/custom.test.ts
@@ -97,7 +97,7 @@ describe("ReconnectableConversationsSocket", () => {
         expect(createReconnectSocket).toHaveBeenCalledWith("conv_123");
     });
 
-    it("creates a new socket on 1012 (fly proxy redeploy) when conversation_id is captured", () => {
+    it("creates a new socket on 1012 (service restart) when conversation_id is captured", () => {
         const { mockSocket, createReconnectSocket } = createSocket();
 
         mockSocket._fire("message", {
@@ -158,8 +158,23 @@ describe("ReconnectableConversationsSocket", () => {
         expect(createReconnectSocket).not.toHaveBeenCalled();
     });
 
-    it.each([1000, 1001, 4000, 4303])(
-        "does NOT create a new socket on non-reconnectable close code %i",
+    // Real close codes observed in production (BetterStack) — every code the
+    // backend actually emits, except the reconnectable ones (1006/1012/
+    // 1001-"restarting"), must NOT trigger a reconnect.
+    it.each<[number, string]>([
+        [1000, "normal closure"],
+        [1001, "going away — bare (user/caller ended)"],
+        [1005, "no status received"],
+        [1011, "server internal error"],
+        [4000, "downstream websocket closed"],
+        [4004, "insufficient capacity"],
+        [4010, "concurrency limit reached"],
+        [4200, "end conversation clicked"],
+        [4500, "no input received timeout"],
+        [4600, "assistant ended conversation"],
+        [4700, "component unmounted"],
+    ])(
+        "does NOT create a new socket on non-reconnectable close code %i (%s)",
         (code) => {
             const { mockSocket, createReconnectSocket } = createSocket();
 

--- a/tests/custom.test.ts
+++ b/tests/custom.test.ts
@@ -97,6 +97,45 @@ describe("ReconnectableConversationsSocket", () => {
         expect(createReconnectSocket).toHaveBeenCalledWith("conv_123");
     });
 
+    it("creates a new socket on 1012 (fly proxy redeploy) when conversation_id is captured", () => {
+        const { mockSocket, createReconnectSocket } = createSocket();
+
+        mockSocket._fire("message", {
+            data: JSON.stringify({ type: "conversation_created", conversation_id: "conv_123" }),
+        });
+
+        mockSocket._fire("close", { code: 1012, reason: "restarting" });
+        jest.advanceTimersByTime(1000);
+
+        expect(createReconnectSocket).toHaveBeenCalledWith("conv_123");
+    });
+
+    it("creates a new socket on 1001 when reason is restarting", () => {
+        const { mockSocket, createReconnectSocket } = createSocket();
+
+        mockSocket._fire("message", {
+            data: JSON.stringify({ type: "conversation_created", conversation_id: "conv_123" }),
+        });
+
+        mockSocket._fire("close", { code: 1001, reason: "restarting" });
+        jest.advanceTimersByTime(1000);
+
+        expect(createReconnectSocket).toHaveBeenCalledWith("conv_123");
+    });
+
+    it("does NOT create a new socket on a bare 1001 (going away — user closed/ended)", () => {
+        const { mockSocket, createReconnectSocket } = createSocket();
+
+        mockSocket._fire("message", {
+            data: JSON.stringify({ type: "conversation_created", conversation_id: "conv_123" }),
+        });
+
+        mockSocket._fire("close", { code: 1001, reason: "" });
+        jest.advanceTimersByTime(10000);
+
+        expect(createReconnectSocket).not.toHaveBeenCalled();
+    });
+
     it("cancels RWS auto-reconnect on 1006 by calling close()", () => {
         const { mockSocket } = createSocket();
 
@@ -119,8 +158,8 @@ describe("ReconnectableConversationsSocket", () => {
         expect(createReconnectSocket).not.toHaveBeenCalled();
     });
 
-    it.each([1000, 4000, 4303])(
-        "does NOT create a new socket on non-1006 close code %i",
+    it.each([1000, 1001, 4000, 4303])(
+        "does NOT create a new socket on non-reconnectable close code %i",
         (code) => {
             const { mockSocket, createReconnectSocket } = createSocket();
 


### PR DESCRIPTION
## What

The reconnect wrapper only resumed a conversation on close code **1006**. But an edge proxy / load-balancer restart closes the **client** with **1012/"restarting"** (and can surface as **1001/"restarting"**), so those drops silently ended the conversation instead of reconnecting.

Expands the predicate to `isReconnectableClose(code, reason)`:
- **1006** abnormal closure
- **1012** service restart
- **1001** only when `reason == "restarting"` — never a **bare 1001** (a deliberate "going away": caller ended it, tab closed/suspended)

Reconnect still re-auths with the API key. Stale "10s grace" comments corrected to 30s.

## Dependency

Depends only on a server-side change that is already deployed in production — safe to release on its own.

## Tests

Reconnect on 1006/1012/1001-restarting; no reconnect on bare 1001 or any other real backend close code observed in production (1000/1005/1011/4000/4004/4010/4200/4500/4600/4700). **27 unit tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> When `reconnectConversationOnAbnormalDisconnect` is enabled, reconnect predicates change live session behavior; misclassification could resume ended calls or skip needed resumes, though tests and server alignment mitigate this.
> 
> **Overview**
> Bumps the SDK to **0.32.10** and broadens **experimental** conversation resume so proxy/load-balancer restarts are handled like abrupt drops.
> 
> `ReconnectableConversationsSocket` no longer treats **1006** as the only recoverable close. It uses **`isReconnectableClose(code, reason)`** aligned with the server: **1006**, **1012**, and **1001** only when `reason === "restarting"`. A **bare 1001** (user ended, tab closed) still does **not** auto-reconnect. Session resume still goes through `reconnect_conv_id` when a `conversation_id` exists.
> 
> `PhonicClient` / `ConversationsClient` docs now describe those close codes. Stale **10s** grace comments are corrected to **30s**. Unit tests cover the new reconnect cases and production non-reconnectable codes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef18d51d23e7dc809c152204c371fe90f4bad5cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic reconnection after service restarts and recognized restarting connections.
  * Prevented unnecessary reconnection attempts for non-recoverable connection closures.
  * Improved conversation recovery when a conversation identifier is available.
  * Extended the reconnection grace period to 30 seconds.
* **Tests**
  * Expanded coverage for recoverable and non-recoverable WebSocket close scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->